### PR TITLE
Don't show diffs from strongSwan secrets file.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -41,9 +41,11 @@ class strongswan::config {
   }
 
   concat {  $strongswan::params::ipsec_secrets:
-    mode  => '0600',
-    owner => 'root',
-    group => 'root',
+    mode      => '0600',
+    owner     => 'root',
+    group     => 'root',
+    show_diff => false,
+    backup    => false,
   }
 
   concat::fragment { 'ipsec_secrets_header':


### PR DESCRIPTION
## Don't show diffs from strongSwan secrets file.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

The stongSwans secrets template will shows diffs when created or updating, which can leak secrets when stdout is being recorded or logged. This PR updates the `concat` declaration to suppress output for this file.

#### This Pull Request (PR) fixes the following issues

StrongSwan secrets from leaking during Puppet applies.