### PR TITLE
strongswan::secrets support selectors

### DIFF
--- a/manifests/secrets.pp
+++ b/manifests/secrets.pp
@@ -1,6 +1,8 @@
-# Configure a strongSwan secrets configuration.
+# StrongSwan secrets configuration.
+# **$selectors** - list of selectors for current secret(@see ipsec.secrets(5))
 define strongswan::secrets(
-  $options = {},
+  Array[String[1]] $selectors = [$title],
+  Hash $options               = {},
 ) {
   concat::fragment { "ipsec_secrets_secret-${title}":
     content => template('strongswan/ipsec_secrets_secret.erb'),

--- a/spec/defines/secrets_spec.rb
+++ b/spec/defines/secrets_spec.rb
@@ -24,8 +24,38 @@ describe 'strongswan::secrets', type: :define do
 
       it {
         is_expected.to contain_concat__fragment('ipsec_secrets_secret-user'). \
-          with_content(%r{: ECDSA user\.der})
+          with_content(%r{user : ECDSA user\.der})
       }
+      context 'with empty selectors' do
+        let :params do
+          {
+            selectors: [],
+            options: {
+              'RSA' => 'server.key'
+            }
+          }
+        end
+
+        it {
+          is_expected.to contain_concat__fragment('ipsec_secrets_secret-user'). \
+            with_content(%r{^ : RSA server.key})
+        }
+      end
+      context 'with selectors' do
+        let :params do
+          {
+            selectors: ['my_id', '10.1.2.3'],
+            options: {
+              'ECDSA' => 'user.der'
+            }
+          }
+        end
+
+        it {
+          is_expected.to contain_concat__fragment('ipsec_secrets_secret-user'). \
+            with_content(%r{my_id 10.1.2.3 : ECDSA user\.der})
+        }
+      end
     end
   end
 end

--- a/templates/ipsec_secrets_secret.erb
+++ b/templates/ipsec_secrets_secret.erb
@@ -1,4 +1,4 @@
 # Secrets for <%= @title %>.
 <% @options.each do |option, setting| -%>
-<%= @title -%> : <%= option -%> <%= setting -%>
+<%= @selectors.join(' ') -%> : <%= option -%> <%= setting -%>
 <% end %>


### PR DESCRIPTION
#### Pull Request (PR) description

allow use of selectors in strongswan::secrets resource

previous behavior is not changed, but now if one needs a list of selectors of even no selectors, logic allows this.