### PR TITLE
Fix PKI for Debian systems and enable acceptance tests

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,3 +1,10 @@
 ---
 .travis.yml:
   secure: "SxHlGw6vRvJ3xigMHB/Wu4Ld2yJhZ6rmobHReVnvc5bV4QDZDjXp13iihBC6xglkST6iBWwBDvcMHBUEaiq3H3hltuFn9SKDtNgiJV6AM0rd9hLzlBrUAnx86mhBmEwjdVpfC7+JxiFnE9dC651EcdvmGC5xi1PDUoj1MvT4QmbxdusAfWWQX4HbA2REtjmDlDwD2ciyMyzNj5qqK5dKxN1c0Aqzr6212TgOIbRE4cK2YGC7g7dCUfqX8Sm/DnVhviH45xxKTYlKuymgn/Igjg1njkEm018vrWJffXHfQFWjEan5olgsgXsbnT30BE762EX0tV9IrhikScu3wqvNGP6xgvTtNRpKt1bL41z4931w7yopbEcOpWmtQb7WTBe0s0vGK1qE/APAuqN/38zdauxqCbPhQRsmOCtzbMSuf+iPL+LQ34sES2yBiXrmOY0IaRZQ/9UT73MLbuXFJqpvoNMGIxTdbzNoWwcFHzFZo/JjKleK99D/5W4oi5whrj9xZRhqsmRtzj4XijTNlARwEhM3t/UsP+V4h0+fEBAsYgwfWsx6kVi7cQjc6nfoVhI6nhHkO6luijbd76xOymHGVOXChofswbyycl9YFvMTvtNvcyuyDeNY+IKBNi190s8JhNUn+OS9X+unvVbVzt4IeFsjDxcbbehtsdzzy7JDCIM="
+  docker_sets:
+    - set: ubuntu1604-64
+    - set: ubuntu1804-64
+    - set: centos6-64
+    - set: centos7-64
+    - set: debian8-64
+    - set: debian9-64

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,54 @@ matrix:
   - rvm: 2.4.4
     bundler_args: --without system_tests development release
     env: PUPPET_VERSION="~> 5.0" CHECK=build DEPLOY_TO_FORGE=yes
+  - rvm: 2.5.3
+    bundler_args: --without development release
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=ubuntu1604-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    services: docker
+  - rvm: 2.5.3
+    bundler_args: --without development release
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=ubuntu1604-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    services: docker
+  - rvm: 2.5.3
+    bundler_args: --without development release
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=ubuntu1804-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    services: docker
+  - rvm: 2.5.3
+    bundler_args: --without development release
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=ubuntu1804-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    services: docker
+  - rvm: 2.5.3
+    bundler_args: --without development release
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=centos6-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    services: docker
+  - rvm: 2.5.3
+    bundler_args: --without development release
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=centos6-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    services: docker
+  - rvm: 2.5.3
+    bundler_args: --without development release
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=centos7-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    services: docker
+  - rvm: 2.5.3
+    bundler_args: --without development release
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=centos7-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    services: docker
+  - rvm: 2.5.3
+    bundler_args: --without development release
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=debian8-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    services: docker
+  - rvm: 2.5.3
+    bundler_args: --without development release
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=debian8-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    services: docker
+  - rvm: 2.5.3
+    bundler_args: --without development release
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=debian9-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    services: docker
+  - rvm: 2.5.3
+    bundler_args: --without development release
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=debian9-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    services: docker
 branches:
   only:
   - master

--- a/manifests/pki/certificate.pp
+++ b/manifests/pki/certificate.pp
@@ -31,7 +31,7 @@ define strongswan::pki::certificate (
   $san_str = join($san_arr,' ')
 
   exec {"${title} private key":
-    command => "strongswan pki --gen --type rsa --size 2048 --outform der > ${private_key_dir}/${title}.der",
+    command => "${strongswan::pki::ca::pki_command} pki --gen --type rsa --size 2048 --outform der > ${private_key_dir}/${title}.der",
     creates => [ "${private_key_dir}/${title}.der"],
     path    => ['/usr/bin', '/usr/sbin'],
     require => Class['strongswan::pki::ca'],
@@ -46,7 +46,7 @@ define strongswan::pki::certificate (
   }
 
   exec {"${title} certificate":
-    command => "strongswan pki --pub --in ${private_key_dir}/${title}.der --type rsa | strongswan pki --issue --lifetime 730 --cacert ${ca_certificate_dir}/${ca_name}.crt --cakey ${ca_private_key_dir}/${ca_name}.der --dn \"C=${country_code}, O=${organization}, CN=${common_name}\" ${san_str} --flag serverAuth --flag ikeIntermediate --outform der > ${certificate_dir}/${title}.crt",
+    command => "${strongswan::pki::ca::pki_command} pki --pub --in ${private_key_dir}/${title}.der --type rsa | ${strongswan::pki::ca::pki_command} pki --issue --lifetime 730 --cacert ${ca_certificate_dir}/${ca_name}.crt --cakey ${ca_private_key_dir}/${ca_name}.der --dn \"C=${country_code}, O=${organization}, CN=${common_name}\" ${san_str} --flag serverAuth --flag ikeIntermediate --outform der > ${certificate_dir}/${title}.crt",
     creates => [ "${certificate_dir}/${title}.crt"],
     path    => ['/usr/bin', '/usr/sbin'],
     require => File["${private_key_dir}/${title}.der"],

--- a/spec/acceptance/001_base_spec.rb
+++ b/spec/acceptance/001_base_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'strongswan default:' do
+describe 'strongswan default' do
   context 'default parameters' do
     it 'runs successfully' do
       pp = "class { 'strongswan': }
@@ -11,15 +11,23 @@ describe 'strongswan default:' do
       apply_manifest(pp, catch_changes:  true)
     end
   end
-  describe 'componets:' do
+  describe 'components' do
+    case fact('os.family')
+    when 'Debian'
+      ipsec_conf = '/etc/ipsec.conf'
+      ipsec_secrets = '/etc/ipsec.secrets'
+    when 'RedHat'
+      ipsec_conf = '/etc/strongswan/ipsec.conf'
+      ipsec_secrets = '/etc/strongswan/ipsec.secrets'
+    end
     describe package('strongswan') do
       it { is_expected.to be_installed }
     end
-    describe file('/etc/strongswan/ipsec.conf') do
+    describe file(ipsec_conf) do
       it { is_expected.to be_file }
       it { is_expected.to contain 'setup' }
     end
-    describe file('/etc/strongswan/ipsec.secrets') do
+    describe file(ipsec_secrets) do
       it { is_expected.to be_file }
     end
     describe service('strongswan') do

--- a/spec/acceptance/002_pki_spec.rb
+++ b/spec/acceptance/002_pki_spec.rb
@@ -1,6 +1,12 @@
 require 'spec_helper_acceptance'
 
 describe 'pki:' do
+  case fact('os.family')
+  when 'Debian'
+    ipsec_d_dir = '/etc/ipsec.d'
+  when 'RedHat'
+    ipsec_d_dir = '/etc/strongswan/ipsec.d'
+  end
   describe 'default' do
     it 'runs successfully' do
       pp = 'class {"strongswan":}
@@ -23,27 +29,27 @@ describe 'pki:' do
   describe service('strongswan') do
     it { is_expected.to be_running }
   end
-  describe file('/etc/strongswan/ipsec.d/private/StrongswanVPN.der') do
+  describe file("#{ipsec_d_dir}/private/StrongswanVPN.der") do
     it { is_expected.to be_file }
     it { is_expected.to be_mode 600 }
   end
-  describe file('/etc/strongswan/ipsec.d/certs/StrongswanVPN.crt') do
+  describe file("#{ipsec_d_dir}/certs/StrongswanVPN.crt") do
     it { is_expected.to be_file }
   end
-  describe file('/etc/strongswan/ipsec.d/certs/StrongswanVPN.pem') do
+  describe file("#{ipsec_d_dir}/certs/StrongswanVPN.pem") do
     it { is_expected.to be_file }
   end
-  describe file('/etc/strongswan/ipsec.d/private/user1.der') do
+  describe file("#{ipsec_d_dir}/private/user1.der") do
     it { is_expected.to be_file }
     it { is_expected.to be_mode 600 }
   end
-  describe file('/etc/strongswan/ipsec.d/certs/user1.crt') do
+  describe file("#{ipsec_d_dir}/certs/user1.crt") do
     it { is_expected.to be_file }
   end
-  describe file('/etc/strongswan/ipsec.d/certs/user1.pem') do
+  describe file("#{ipsec_d_dir}/certs/user1.pem") do
     it { is_expected.to be_file }
   end
-  describe file('/etc/strongswan/ipsec.d/certs/user1.p12') do
+  describe file("#{ipsec_d_dir}/certs/user1.p12") do
     it { is_expected.to be_file }
   end
 end

--- a/spec/acceptance/003_config_spec.rb
+++ b/spec/acceptance/003_config_spec.rb
@@ -1,6 +1,14 @@
 require 'spec_helper_acceptance'
 
 describe 'connection:' do
+  case fact('os.family')
+  when 'Debian'
+    ipsec_conf = '/etc/ipsec.conf'
+    ipsec_secrets = '/etc/ipsec.secrets'
+  when 'RedHat'
+    ipsec_conf = '/etc/strongswan/ipsec.conf'
+    ipsec_secrets = '/etc/strongswan/ipsec.secrets'
+  end
   describe 'default' do
     it 'runs successfully' do
       pp = '
@@ -44,12 +52,12 @@ describe 'connection:' do
   describe service('strongswan') do
     it { is_expected.to be_running }
   end
-  describe file('/etc/strongswan/ipsec.conf') do
+  describe file(ipsec_conf) do
     it { is_expected.to be_file }
     it { is_expected.to contain 'conn IKEv2-EAP' }
     it { is_expected.to contain 'conn %default' }
   end
-  describe file('/etc/strongswan/ipsec.secrets') do
+  describe file(ipsec_secrets) do
     it { is_expected.to be_file }
     it { is_expected.to contain '  : RSA server.der' }
   end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,30 +1,18 @@
 require 'beaker-rspec'
+require 'beaker-puppet'
 require 'beaker/puppet_install_helper'
+require 'beaker/module_install_helper'
 
-hosts.each do |host|
-  install_puppet
-  install_package host, 'net-tools'
-  install_package host, 'make'
-  install_package host, 'gcc'
-  install_package host, 'ruby-devel'
-  install_package host, 'epel-release'
-  install_package host, 'openssl'
-  on host, 'yum makecache'
-end
+run_puppet_install_helper unless ENV['BEAKER_provision'] == 'no'
+install_module_on(hosts)
+install_module_dependencies_on(hosts)
 
 RSpec.configure do |c|
-  # Project root
-  proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
-
-  # Readable test descriptions
   c.formatter = :documentation
 
-  # Configure all nodes in nodeset
   c.before :suite do
-    puppet_module_install(source: proj_root, module_name: 'strongswan')
     hosts.each do |host|
-      on host, puppet('module', 'install', 'puppetlabs-stdlib'), acceptable_exit_codes: [0, 1]
-      on host, puppet('module', 'install', 'puppetlabs-concat'), acceptable_exit_codes: [0, 1]
+      install_package(host, 'epel-release') if fact('os.family') == 'RedHat'
     end
   end
 end


### PR DESCRIPTION
Debian family doesn't have a `strongswan` command.  Instead it uses `ipsec`.
In some variants, the `strongswan-pki` package needs to be installed first.
    
Fixes #39

Acceptance tests are fixed up and enabled for OSes that are in metadata.json
Fixes #37 